### PR TITLE
Add zero-width space to empty leafs

### DIFF
--- a/src/SlateReactPresentation.tsx
+++ b/src/SlateReactPresentation.tsx
@@ -30,7 +30,7 @@ function Leaf({ leaf = { text: '' } }: LeafProps) {
 
   return (
     <React.Fragment>
-      {renderLeaf?.({ attributes: {} as any, children: <LeafWrapper>{leaf.text}</LeafWrapper>, leaf, text: leaf })}
+      {renderLeaf?.({ attributes: {} as any, children: <LeafWrapper>{leaf.text === '' ? '\uFEFF' : leaf.text}</LeafWrapper>, leaf, text: leaf })}
     </React.Fragment>
   )
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,7 +22,7 @@ export type SlatePresentationContextProps = {
 
 export type SlateReactPresentationProps = {
   value?: Descendant[]
-  renderElement: EditableProps['renderElement']
-  renderLeaf: EditableProps['renderLeaf']
-  LeafWrapper: React.ComponentType | keyof JSX.IntrinsicElements
+  renderElement?: EditableProps['renderElement']
+  renderLeaf?: EditableProps['renderLeaf']
+  LeafWrapper?: React.ComponentType | keyof JSX.IntrinsicElements
 }


### PR DESCRIPTION
Fixes #9

This PR does two things:
1. Inserts a zero-width space to all empty leafs, to match the behavior of the `slate` editor. It should prevent the empty div/paragraph from shrinking.
2. Makes all the props of `SlateReactPresentation` optional - there were already default values specified, but since the props were required, these were never used (except for `value` which was optional). I personally was a little confused at first what is expected of me in the `LeafWrapper` prop and had to pass `'span'` just to make it work.